### PR TITLE
fix Hex metadata

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,7 +16,7 @@
     :CUSTOM_ID: changed
     :END:
 
-- Fix URL in Hex metadata
+- Fix URL in Hex metadata.
 
 ** 1.8.8 - 2019-02-15
    :PROPERTIES:

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,6 +6,18 @@
   :CUSTOM_ID: change-log
   :END:
 
+** 1.8.9 - 2019-02-20
+   :PROPERTIES:
+   :CUSTOM_ID: section
+   :END:
+
+*** Changed
+    :PROPERTIES:
+    :CUSTOM_ID: changed
+    :END:
+
+- Fix URL in Hex metadata
+
 ** 1.8.8 - 2019-02-15
    :PROPERTIES:
    :CUSTOM_ID: section

--- a/src/re2.app.src
+++ b/src/re2.app.src
@@ -1,6 +1,6 @@
 {application, re2,
  [ {description, "Erlang NIF bindings for the RE2 regex library"}
- , {vsn, "1.8.8"}
+ , {vsn, "1.8.9"}
  , {modules, [re2]}
  , {registered, []}
  , {applications, [ kernel


### PR DESCRIPTION
To fix the URL, I need a new tag for Hex (sorry, I didn't catch it within the 1 hour window).

I also pushed the 1.8.9 tag, not remembering that the `.app.src` uses explicit versions and not the `git` magic. If nobody minds, I'll move the tag after merging this PR (if you _do_ mind moving Git tags, I can bump the version here to 1.8.10 and do it that way).