### PR TITLE
Switch back to eunit default opts

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -183,7 +183,6 @@ GeneralOpts = [ {plugins, [PCDep]}
                     , {clean, {pc, clean}}
                     ]}
                  ]}
-              , {eunit_opts, [verbose]}
               , {profiles
                 , [ {test
                     , [ {deps, TestDeps}


### PR DESCRIPTION
Now that rebar3's eunit reporting issues are resolved, we can switch to default options.