### PR TITLE
Don't use -m$ERLANG_ARCH on ARM

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -5,6 +5,7 @@ test `basename $PWD` != "c_src" && cd c_src
 
 IS_WINDOWS=no
 IS_MACOS=no
+IS_ARM=no
 
 case "$(uname -s)" in
     Darwin)
@@ -12,6 +13,12 @@ case "$(uname -s)" in
         ;;
     CYGWIN*|MINGW*)
         IS_WINDOWS=yes
+        ;;
+esac
+
+case "$(uname -m)" in
+    armv*)
+        IS_ARM=yes
         ;;
 esac
 
@@ -71,7 +78,7 @@ case "$1" in
                 cp $LIB $LIBRE2
             )
         else
-            if [ x"$IS_MACOS" = x"no" ]; then
+            if [ x"$IS_MACOS" = x"no" ] && [ x"$IS_ARM" = x"no" ]; then
                 ERLANG_FLAGS="-m$ERLANG_ARCH"
             else
                 ERLANG_FLAGS=""


### PR DESCRIPTION
...it fails with `c++: error: unrecognized command line option "-m32"; did you mean "-mbe32"?`

Also, BE32 is obsolete, ref: https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html

Tested on Raspbian Buster, RPi1B/256Mb, armv6