### PR TITLE
Just update to a recent version

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -29,7 +29,7 @@ case "$1" in
         fi
         test -f re2/$LIBRE2 && exit 0
 
-        RE2_REV=${RE2_REV:-2022-06-01}
+        RE2_REV=${RE2_REV:-2023-03-01}
         case $(git config --get remote.origin.url) in
             git@github.com*|https://github.com*|git://github.com*)
                 RE2_DEFAULT_URL=https://github.com/google/re2

--- a/src/re2.app.src
+++ b/src/re2.app.src
@@ -1,6 +1,6 @@
 {application, re2,
  [ {description, "Erlang NIF bindings for RE2 regex library"}
- , {vsn, "1.9.8"}
+ , {vsn, "1.9.9"}
  , {modules, [re2]}
  , {registered, []}
  , {applications, [ kernel


### PR DESCRIPTION
According to README 2023-06-01 requires Abseil, so we'll stop at `2023-03-01`.

Also, 2023-03-01 is latest version shipped with Debian bookworm, so we
might take from there any patch for the next years without worrying
about bumping this library version.